### PR TITLE
[feature] 관리자 기능 추가

### DIFF
--- a/src/main/java/com/ocho/what2do/admin/controller/AdminStoreController.java
+++ b/src/main/java/com/ocho/what2do/admin/controller/AdminStoreController.java
@@ -1,0 +1,66 @@
+package com.ocho.what2do.admin.controller;
+
+
+import com.ocho.what2do.common.dto.ApiResponseDto;
+import com.ocho.what2do.common.security.UserDetailsImpl;
+import com.ocho.what2do.admin.dto.AdminStoreListResponseDto;
+import com.ocho.what2do.admin.dto.AdminStoreRequestDto;
+import com.ocho.what2do.admin.dto.AdminStoreResponseDto;
+import com.ocho.what2do.admin.dto.AdminStoreViewResponseDto;
+import com.ocho.what2do.admin.service.AdminStoreService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+public class AdminStoreController {
+
+  private final AdminStoreService storeService;
+
+  @Operation(summary = "관리자 가게 등록", description = "가게를 등록합니다.")
+  @PostMapping("/stores") //가게 등록
+  public ResponseEntity<AdminStoreResponseDto> createStore(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody AdminStoreRequestDto requestDto) {
+    return new ResponseEntity<>(storeService.createStore(requestDto, userDetails.getUser()), HttpStatus.OK);
+  }
+
+  @Operation(summary = "관리자 가게 전체 조회", description = "가게를 조회합니다.")
+  @GetMapping("/stores") //가게 전체 조회
+  public ResponseEntity<AdminStoreListResponseDto> getStores() {
+    AdminStoreListResponseDto result = storeService.getStores();
+
+    return ResponseEntity.ok().body(result);
+  }
+
+  @Operation(summary = "관리자 가게 전체 조회", description = "가게를 조회합니다.")
+  @GetMapping("/stores/{storeId}") //가게 단건 조회
+  public ResponseEntity<AdminStoreViewResponseDto> getStoreById(@PathVariable Long storeId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    return new ResponseEntity<>(storeService.getStoreById(storeId, userDetails.getUser()), HttpStatus.OK);
+  }
+
+  @Operation(summary = "관리자 가게 수정", description = "가게를 수정합니다.")
+  @PutMapping("/stores/{storeId}") //가게 수정
+  public ResponseEntity<ApiResponseDto> updateStore(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long storeId, @RequestBody AdminStoreRequestDto requestDto) {
+    AdminStoreResponseDto result;
+    result = storeService.updateStore(storeId, requestDto, userDetails.getUser());
+    return ResponseEntity.ok().body(result);
+  }
+
+  @Operation(summary = "관리자 가게 삭제", description = "가게를 삭제합니다.")
+  @DeleteMapping("/stores/{storeId}") //가게 삭제
+  public ResponseEntity<ApiResponseDto> deleteStore(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long storeId) {
+    storeService.deleteStore(storeId, userDetails.getUser());
+    return ResponseEntity.ok().body(new ApiResponseDto(HttpStatus.OK.value(), "가게 삭제 성공"));
+  }
+}

--- a/src/main/java/com/ocho/what2do/admin/controller/AdminUserController.java
+++ b/src/main/java/com/ocho/what2do/admin/controller/AdminUserController.java
@@ -1,0 +1,43 @@
+package com.ocho.what2do.admin.controller;
+
+import com.ocho.what2do.admin.dto.TokenRequestDto;
+import com.ocho.what2do.admin.dto.UserLockRequestDto;
+import com.ocho.what2do.admin.dto.UserRoleRequestDto;
+import com.ocho.what2do.admin.service.AdminUserServiceImpl;
+import com.ocho.what2do.common.dto.ApiResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminUserController {
+
+  private final AdminUserServiceImpl adminUserService;
+  @Operation(summary = "관리자 토큰 확인", description = "관리자 토큰 확인합니다.")
+  @PostMapping("/checks")
+  public ResponseEntity<ApiResponseDto> checkToken(@RequestBody TokenRequestDto requestDto) {
+    return ResponseEntity.ok(adminUserService.checkToken(requestDto.getToken()));
+  }
+
+  @Operation(summary = "관리자의 사용자 정지", description = "관리자가 사용자의 로그인 가능 여부를 처리합니다.")
+  @PatchMapping("/users/lock")
+  public ResponseEntity<ApiResponseDto> lockUser(@RequestBody UserLockRequestDto requestDto) {
+    return ResponseEntity.ok(adminUserService.lockUser(requestDto));
+  }
+
+  @Operation(summary = "관리자의 사용자 권한 수정", description = "관리자가 사용자의 권한을 처리합니다.")
+  @PutMapping("/users/role")
+  public ResponseEntity<ApiResponseDto> changeRole(@RequestBody UserRoleRequestDto requestDto) {
+    return ResponseEntity.ok(
+        adminUserService.changeRole(requestDto.getEmail(), requestDto.getRole()));
+  }
+
+}

--- a/src/main/java/com/ocho/what2do/admin/dto/AdminStoreListResponseDto.java
+++ b/src/main/java/com/ocho/what2do/admin/dto/AdminStoreListResponseDto.java
@@ -1,0 +1,13 @@
+package com.ocho.what2do.admin.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class AdminStoreListResponseDto {
+    private List<AdminStoreResponseDto> storesList;
+
+    public AdminStoreListResponseDto(List<AdminStoreResponseDto> storeList) {
+        this.storesList = storeList;
+    }
+}

--- a/src/main/java/com/ocho/what2do/admin/dto/AdminStoreRequestDto.java
+++ b/src/main/java/com/ocho/what2do/admin/dto/AdminStoreRequestDto.java
@@ -1,0 +1,28 @@
+package com.ocho.what2do.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AdminStoreRequestDto {
+    private String title;
+    private String homePageLink;
+    private String category;
+    private String address;
+    private String roadAddress;
+    private String latitude;
+    private String longitude;
+
+    @Builder
+    public AdminStoreRequestDto(String title, String homePageLink, String category, String address, String roadAddress, String latitude, String longitude) {
+        this.title = title;
+        this.homePageLink = homePageLink;
+        this.category = category;
+        this.address = address;
+        this.roadAddress = roadAddress;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/src/main/java/com/ocho/what2do/admin/dto/AdminStoreResponseDto.java
+++ b/src/main/java/com/ocho/what2do/admin/dto/AdminStoreResponseDto.java
@@ -1,0 +1,35 @@
+package com.ocho.what2do.admin.dto;
+
+import com.ocho.what2do.common.dto.ApiResponseDto;
+import com.ocho.what2do.store.entity.Store;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminStoreResponseDto extends ApiResponseDto {
+    private Long id;
+    private String title;
+    private String homePageLink;
+    private String category;
+    private String address;
+    private String roadAddress;
+    private String latitude;
+    private String longitude;
+//    private List<StoreCategory> storeCategoryList;
+
+    private boolean isStoreFavorite = false;
+
+    public AdminStoreResponseDto(Store store) {
+        this.id = store.getId();
+        this.title = store.getTitle();
+        this.homePageLink = store.getHomePageLink();
+        this.category = store.getCategory();
+        this.address = store.getAddress();
+        this.roadAddress = store.getRoadAddress();
+        this.latitude = store.getLatitude();
+        this.longitude = store.getLongitude();
+//        this.storeCategoryList = store.getStoreCategoryList().stream().toList();
+        this.isStoreFavorite = false;
+    }
+}

--- a/src/main/java/com/ocho/what2do/admin/dto/AdminStoreViewResponseDto.java
+++ b/src/main/java/com/ocho/what2do/admin/dto/AdminStoreViewResponseDto.java
@@ -1,0 +1,34 @@
+package com.ocho.what2do.admin.dto;
+
+import com.ocho.what2do.store.entity.Store;
+import com.ocho.what2do.storecategory.entity.StoreCategory;
+import com.ocho.what2do.user.entity.User;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminStoreViewResponseDto {
+
+    private Long id;
+    private String title;
+    private String homePageLink;
+    private String category;
+    private String address;
+    private String roadAddress;
+    private List<StoreCategory> storeCategoryList;
+
+    private boolean isStoreFavorite = false;
+
+    public AdminStoreViewResponseDto(Store store, User user) {
+        this.id = store.getId();
+        this.title = store.getTitle();
+        this.homePageLink = store.getHomePageLink();
+        this.category = store.getCategory();
+        this.address = store.getAddress();
+        this.roadAddress = store.getRoadAddress();
+//        this.storeCategoryList = store.getStoreCategoryList().stream().toList();
+        this.isStoreFavorite = (user == null ? false : store.getStoreFavoriteList().stream().filter(m -> m.getUser().getId() == user.getId()).toList().size() > 0 ? true : false);
+    }
+}

--- a/src/main/java/com/ocho/what2do/admin/dto/TokenRequestDto.java
+++ b/src/main/java/com/ocho/what2do/admin/dto/TokenRequestDto.java
@@ -1,0 +1,8 @@
+package com.ocho.what2do.admin.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TokenRequestDto {
+  private String token;
+}

--- a/src/main/java/com/ocho/what2do/admin/dto/UserLockRequestDto.java
+++ b/src/main/java/com/ocho/what2do/admin/dto/UserLockRequestDto.java
@@ -1,0 +1,9 @@
+package com.ocho.what2do.admin.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserLockRequestDto {
+  private String email;
+  private boolean locked;
+}

--- a/src/main/java/com/ocho/what2do/admin/dto/UserRoleRequestDto.java
+++ b/src/main/java/com/ocho/what2do/admin/dto/UserRoleRequestDto.java
@@ -1,0 +1,9 @@
+package com.ocho.what2do.admin.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserRoleRequestDto {
+  private String email;
+  private String role;
+}

--- a/src/main/java/com/ocho/what2do/admin/service/AdminStoreService.java
+++ b/src/main/java/com/ocho/what2do/admin/service/AdminStoreService.java
@@ -1,0 +1,56 @@
+package com.ocho.what2do.admin.service;
+
+import com.ocho.what2do.admin.dto.AdminStoreListResponseDto;
+import com.ocho.what2do.admin.dto.AdminStoreRequestDto;
+import com.ocho.what2do.admin.dto.AdminStoreResponseDto;
+import com.ocho.what2do.admin.dto.AdminStoreViewResponseDto;
+import com.ocho.what2do.store.entity.Store;
+import com.ocho.what2do.user.entity.User;
+
+public interface AdminStoreService {
+
+  /**
+   * 가게 생성
+   * @param requestDto 가게 생성 요청 정보
+   * @param user 가게 생성 요청자
+   * @return 가게 생성 결과
+   */
+  AdminStoreResponseDto createStore(AdminStoreRequestDto requestDto, User user);
+
+  /**
+   * 전체 가게 목록 조회
+   * @return 전체 가게 목록
+   */
+  AdminStoreListResponseDto getStores();
+
+  /**
+   * 가게 단건 조회
+   * @param storeId 조회할 가게 ID
+   * @return 조회된 가게 정보
+   */
+  AdminStoreViewResponseDto getStoreById(Long storeId, User user);
+
+  /**
+   * 가게 업데이트
+   * @param storeId 업데이트 할 가게
+   * @param requestDto 업데이트 할 가게 정보
+   * @param user 가게 업데이트 요청자
+   * @return 업데이트된 가게 정보
+   */
+  AdminStoreResponseDto updateStore(Long storeId, AdminStoreRequestDto requestDto, User user);
+
+  /**
+   * 가게 삭제
+   * @param storeId 삭제 요청 가게
+   * @param user 가게 삭제 요청자
+   */
+  void deleteStore(Long storeId, User user);
+
+  /**
+   * 가게 Entity 단건 조회
+   * @param storeId 조회할 가게 ID
+   * @return 가게 Entity
+   */
+  Store findStore(Long storeId);
+
+}

--- a/src/main/java/com/ocho/what2do/admin/service/AdminStoreServiceImpl.java
+++ b/src/main/java/com/ocho/what2do/admin/service/AdminStoreServiceImpl.java
@@ -1,0 +1,75 @@
+package com.ocho.what2do.admin.service;
+
+import com.ocho.what2do.admin.dto.AdminStoreListResponseDto;
+import com.ocho.what2do.admin.dto.AdminStoreRequestDto;
+import com.ocho.what2do.admin.dto.AdminStoreResponseDto;
+import com.ocho.what2do.admin.dto.AdminStoreViewResponseDto;
+import com.ocho.what2do.common.exception.CustomException;
+import com.ocho.what2do.common.message.CustomErrorCode;
+import com.ocho.what2do.store.entity.Store;
+import com.ocho.what2do.store.repository.StoreRepository;
+import com.ocho.what2do.user.entity.User;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminStoreServiceImpl implements AdminStoreService {
+
+  private final StoreRepository storeRepository;
+
+  @Override
+  @Transactional
+  public AdminStoreResponseDto createStore(AdminStoreRequestDto requestDto, User user) {
+    Store store = Store.builder().title(requestDto.getTitle())
+        .homePageLink(requestDto.getHomePageLink())
+        .category(requestDto.getCategory())
+        .address(requestDto.getAddress())
+        .roadAddress(requestDto.getRoadAddress())
+        .latitude(requestDto.getLatitude())
+        .longitude(requestDto.getLongitude())
+        .build();
+    return new AdminStoreResponseDto(storeRepository.save(store));
+
+  }
+
+  @Override
+  @Transactional
+  public AdminStoreListResponseDto getStores() {
+    List<AdminStoreResponseDto> storeList = storeRepository.findAll().stream()
+        .map(AdminStoreResponseDto::new).collect(
+            Collectors.toList());
+    return new AdminStoreListResponseDto(storeList);
+  }
+
+  @Override
+  @Transactional
+  public AdminStoreViewResponseDto getStoreById(Long storeId, User user) {
+    Store store = findStore(storeId);
+    return new AdminStoreViewResponseDto(store, user);
+  }
+
+  @Override
+  @Transactional
+  public AdminStoreResponseDto updateStore(Long storeId, AdminStoreRequestDto requestDto,
+      User user) {
+    Store store = findStore(storeId);
+    store.updateAdmin(requestDto);
+    return new AdminStoreResponseDto(store);
+  }
+
+  @Override
+  @Transactional
+  public void deleteStore(Long storeId, User user) {
+    storeRepository.deleteById(storeId);
+  }
+
+  @Override
+  public Store findStore(Long storeId) {
+    return storeRepository.findById(storeId)
+        .orElseThrow(() -> new CustomException(CustomErrorCode.STORE_NOT_FOUND, null));
+  }
+}

--- a/src/main/java/com/ocho/what2do/admin/service/AdminUserService.java
+++ b/src/main/java/com/ocho/what2do/admin/service/AdminUserService.java
@@ -1,0 +1,31 @@
+package com.ocho.what2do.admin.service;
+
+import com.ocho.what2do.admin.dto.UserLockRequestDto;
+import com.ocho.what2do.common.dto.ApiResponseDto;
+import com.ocho.what2do.user.entity.UserRoleEnum;
+import org.springframework.http.ResponseEntity;
+
+public interface AdminUserService {
+
+  /**
+   * 관리자 여부 확인
+   * @param token 관리자 토큰
+   * @return 성공 여부
+   */
+  ApiResponseDto checkToken(String token);
+
+  /**
+   * 권한 변경
+   * @param email 이메일
+   * @param roleName 권한
+   * @return 성공 여부
+   */
+  ApiResponseDto changeRole(String email, String roleName);
+
+  /**
+   * 회원 정지
+   * @param userLockRequestDto 회원 정보
+   * @return 성공 여부
+   */
+  ApiResponseDto lockUser(UserLockRequestDto userLockRequestDto);
+}

--- a/src/main/java/com/ocho/what2do/admin/service/AdminUserServiceImpl.java
+++ b/src/main/java/com/ocho/what2do/admin/service/AdminUserServiceImpl.java
@@ -1,0 +1,72 @@
+package com.ocho.what2do.admin.service;
+
+import com.ocho.what2do.admin.dto.UserLockRequestDto;
+import com.ocho.what2do.common.dto.ApiResponseDto;
+import com.ocho.what2do.common.exception.CustomException;
+import com.ocho.what2do.common.message.CustomErrorCode;
+import com.ocho.what2do.user.entity.User;
+import com.ocho.what2do.user.entity.UserRoleEnum;
+import com.ocho.what2do.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUserServiceImpl implements AdminUserService {
+
+  @Value("${admin.token}")
+  private String adminToken;
+
+  private final UserRepository userRepository;
+
+  @Override
+  public ApiResponseDto checkToken(String token) {
+    if (!token.equals(adminToken)) {
+      throw new CustomException(CustomErrorCode.NOT_ADMIN_AUTH);
+    }
+
+    return new ApiResponseDto(HttpStatus.OK.value(), "관리자 확인 완료하였습니다.");
+  }
+
+  @Override
+  @Transactional
+  public ApiResponseDto changeRole(String email, String roleName) {
+    User user = findUserByEmail(email);
+    UserRoleEnum role = user.getRole();
+    int num = 0;
+    if (roleName.equals("ADMIN")) {
+      role = UserRoleEnum.ADMIN;
+    } else if (roleName.equals("USER")) {
+      role = UserRoleEnum.USER;
+    } else if (roleName.equals("GUEST")) {
+      role = UserRoleEnum.GUEST;
+    } else {
+      throw new CustomException(CustomErrorCode.HAVE_NOT_USER_ROLE, null);
+    }
+    user.updateRole(role);
+
+    return new ApiResponseDto(HttpStatus.OK.value(), "사용자 권한 수정 완료하였습니다.");
+  }
+
+  @Override
+  @Transactional
+  public ApiResponseDto lockUser(UserLockRequestDto userLockRequestDto) {
+    User user = findUserByEmail(userLockRequestDto.getEmail());
+    user.userLock(userLockRequestDto.isLocked());
+    return new ApiResponseDto(HttpStatus.OK.value(), userLockRequestDto.getEmail() + "님은 이제 로그인 하실 수 없습니다.");
+  }
+
+
+  private User findUser(Long userId) {
+    return userRepository.findById(userId).orElseThrow(
+        () -> new CustomException(CustomErrorCode.USER_NOT_FOUND, null));
+  }
+
+  private User findUserByEmail(String email) {
+    return userRepository.findByEmail(email).orElseThrow(
+        () -> new CustomException(CustomErrorCode.USER_NOT_FOUND, null));
+  }
+}

--- a/src/main/java/com/ocho/what2do/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/ocho/what2do/common/config/WebSecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -77,7 +78,7 @@ public class WebSecurityConfig {
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     // CSRF 설정
     http.csrf(AbstractHttpConfigurer::disable);
-    http.cors();
+    http.cors(Customizer.withDefaults());
 
     // Session 방식 -> JWT 방식 설정 변경
     http.sessionManagement(sessionManagement ->
@@ -94,6 +95,7 @@ public class WebSecurityConfig {
             .permitAll()
             .requestMatchers(HttpMethod.GET, "/api/users/checkEmail")
             .permitAll()
+           //  .requestMatchers("/admin/**").permitAll()
             .requestMatchers("/api/naver/**").permitAll() // naver 지역 api 요청 접근 허가
             .requestMatchers("/api/daum/**").permitAll() // daum 지역 api 요청 접근 허가
             .anyRequest().authenticated() // 그 외 모든 요청 인증처리

--- a/src/main/java/com/ocho/what2do/common/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/ocho/what2do/common/jwt/JwtAuthorizationFilter.java
@@ -38,7 +38,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
   private static final String NO_CHECK_URL = "/api/users/login"; // "login"으로 들어오는 요청은 Filter 작동 X
   private static final String NO_CHECK_URL_SIGNUP = "/api/users/signup";
 
-  private static final String START_CHECK_URL_USER = "/api/users";
+  private static final String START_CHECK_URL_ADMIN = "/api/admin";
 
   public static final String AUTHORIZATION_ACCESS_HEADER = "Authorization";
   private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
@@ -51,7 +51,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
       HttpServletRequest req, HttpServletResponse res, FilterChain filterChain)
       throws ServletException, IOException {
     if (req.getRequestURI().equals(NO_CHECK_URL)
-    || req.getRequestURI().equals(NO_CHECK_URL_SIGNUP)) {
+    || req.getRequestURI().equals(NO_CHECK_URL_SIGNUP)
+    ) {
       filterChain.doFilter(req, res); // "login" 요청이 들어오면, 다음 필터 호출
       return; // return으로 이후 현재 필터 진행 막기 (안해주면 아래로 내려가서 계속 필터 진행시킴)
     }

--- a/src/main/java/com/ocho/what2do/common/message/CustomErrorCode.java
+++ b/src/main/java/com/ocho/what2do/common/message/CustomErrorCode.java
@@ -27,6 +27,9 @@ public enum CustomErrorCode {
   REVIEW_NOT_LIKED(HttpStatus.BAD_REQUEST.value()," 이미 좋아요를 누른 리뷰입니다." ),
   STORE_FAVORITE_ALREADY_EXIST(HttpStatus.BAD_REQUEST.value(),"이미 찜한 가게입니다."),
   STORE_FAVORITE_NOT_FOUND(HttpStatus.BAD_REQUEST.value(), "해당 가게에 취소할 찜이 없습니다."),
+  NOT_ADMIN_AUTH(HttpStatus.BAD_REQUEST.value(),"관리자 권한이 없습니다."),
+  HAVE_NOT_USER_ROLE(HttpStatus.BAD_REQUEST.value(),"유효한 사용자 권한이 아닙니다."),
+  LOGIN_USER_ACCOUNT_LOCKED(HttpStatus.BAD_REQUEST.value(),"계정이 정지되었습니다. 관리자에게 문의하세요."),
   ;
 
   private final int errorCode;

--- a/src/main/java/com/ocho/what2do/common/security/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/ocho/what2do/common/security/handler/LoginSuccessHandler.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.LockedException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 
@@ -33,6 +34,13 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
       Authentication authentication) {
     UserRoleEnum role = ((UserDetailsImpl) authentication.getPrincipal()).getUser().getRole();
     String email = extractUsername(authentication); // 인증 정보에서 Username(email) 추출
+
+    // 만약 계정이 정지되었다면
+    if(((UserDetailsImpl) authentication.getPrincipal()).getUser().isLocked()){
+      // 계정정지 예외 발생
+      throw new CustomException(CustomErrorCode.LOGIN_USER_ACCOUNT_LOCKED);
+    }
+
     String accessToken = jwtUtil.createAccessToken(email,
         role); // JwtService의 createAccessToken을 사용하여 AccessToken 발급
     String refreshToken = jwtUtil.createRefreshToken(); // JwtService의 createRefreshToken을 사용하여 RefreshToken 발급

--- a/src/main/java/com/ocho/what2do/store/controller/StoreController.java
+++ b/src/main/java/com/ocho/what2do/store/controller/StoreController.java
@@ -23,11 +23,13 @@ import org.springframework.web.bind.annotation.*;
 public class StoreController {
     private final StoreService storeService;
 
+    @Operation(summary = "가게 등록", description = "가게를 등록합니다.")
     @PostMapping("/stores") //가게 등록
     public ResponseEntity<StoreResponseDto> createStore(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody StoreRequestDto requestDto) {
         return new ResponseEntity<>(storeService.createStore(requestDto, userDetails.getUser()), HttpStatus.OK);
     }
 
+    @Operation(summary = "가게 조회", description = "가게를 조회합니다.")
     @GetMapping("/stores") //가게 전체 조회
     public ResponseEntity<StoreListResponseDto> getStores() {
         StoreListResponseDto result = storeService.getStores();
@@ -35,11 +37,13 @@ public class StoreController {
         return ResponseEntity.ok().body(result);
     }
 
+    @Operation(summary = "가게 단건", description = "가게 단건 조회.")
     @GetMapping("/stores/{storeId}") //가게 단건 조회
     public ResponseEntity<StoreViewResponseDto> getStoreById(@PathVariable Long storeId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return new ResponseEntity<>(storeService.getStoreById(storeId, userDetails.getUser()), HttpStatus.OK);
     }
 
+    @Operation(summary = "가게 수정", description = "가게를 수정합니다.")
     @PutMapping("/stores/{storeId}") //가게 수정
     public ResponseEntity<ApiResponseDto> updateStore(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long storeId, @RequestBody StoreRequestDto requestDto) {
         StoreResponseDto result;
@@ -47,6 +51,7 @@ public class StoreController {
         return ResponseEntity.ok().body(result);
     }
 
+    @Operation(summary = "가게 삭제", description = "가게를 삭제합니다.")
     @DeleteMapping("/stores/{storeId}") //가게 삭제
     public ResponseEntity<ApiResponseDto> deleteStore(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long storeId) {
             storeService.deleteStore(storeId, userDetails.getUser());

--- a/src/main/java/com/ocho/what2do/store/entity/Store.java
+++ b/src/main/java/com/ocho/what2do/store/entity/Store.java
@@ -1,5 +1,6 @@
 package com.ocho.what2do.store.entity;
 
+import com.ocho.what2do.admin.dto.AdminStoreRequestDto;
 import com.ocho.what2do.store.dto.StoreRequestDto;
 import com.ocho.what2do.storefavorite.entity.StoreFavorite;
 import jakarta.persistence.*;
@@ -52,6 +53,17 @@ public class Store {
   }
 
   public void update(StoreRequestDto requestDto){
+    this.title = requestDto.getTitle();
+    this.homePageLink = requestDto.getHomePageLink();
+    this.category = requestDto.getCategory();
+    this.address = requestDto.getAddress();
+    this.roadAddress = requestDto.getRoadAddress();
+    this.latitude = requestDto.getLatitude();
+    this.longitude = requestDto.getLongitude();
+  }
+
+  // 관리자용 업데이트
+  public void updateAdmin(AdminStoreRequestDto requestDto){
     this.title = requestDto.getTitle();
     this.homePageLink = requestDto.getHomePageLink();
     this.category = requestDto.getCategory();

--- a/src/main/java/com/ocho/what2do/user/entity/User.java
+++ b/src/main/java/com/ocho/what2do/user/entity/User.java
@@ -58,6 +58,9 @@ public class User {
     @Column
     private String socialId; // 로그인한 소셜 타입의 식별자 값 (일반 로그인인 경우 null)
 
+    @Column
+    private boolean locked = false;
+
     public User(String email, String password, UserRoleEnum role) {
         this.email = email;
         this.password = password;
@@ -90,6 +93,17 @@ public class User {
         this.nickname = nickname;
         this.introduction = introduction;
         this.picture = picture;
+    }
+
+    public User userLock(boolean locked){
+        this.locked = locked;
+        return this;
+    }
+
+    // 역할 변경
+    public User updateRole(UserRoleEnum role){
+        this.role = role;
+        return this;
     }
 
     // 소셜로그인 시 활용

--- a/src/test/java/com/ocho/what2do/admin/AdminStoreServiceImplTest.java
+++ b/src/test/java/com/ocho/what2do/admin/AdminStoreServiceImplTest.java
@@ -1,0 +1,194 @@
+package com.ocho.what2do.admin;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+import com.ocho.what2do.admin.dto.AdminStoreRequestDto;
+import com.ocho.what2do.admin.dto.AdminStoreResponseDto;
+import com.ocho.what2do.admin.dto.AdminStoreViewResponseDto;
+import com.ocho.what2do.admin.service.AdminStoreServiceImpl;
+import com.ocho.what2do.common.exception.CustomException;
+import com.ocho.what2do.store.repository.StoreRepository;
+import com.ocho.what2do.user.dto.SignupRequestDto;
+import com.ocho.what2do.user.entity.User;
+import com.ocho.what2do.user.repository.UserRepository;
+import com.ocho.what2do.user.service.UserServiceImpl;
+import java.io.IOException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class AdminStoreServiceImplTest {
+  @Autowired
+  private UserServiceImpl userService;
+  @Autowired
+  private AdminStoreServiceImpl storeService;
+  @Autowired
+  private UserRepository userRepository;
+  @Autowired
+  private StoreRepository storeRepository;
+  @BeforeEach
+  void setMasterInfo() {
+    Optional<User> user1 = userRepository.findByEmail("test01@email.com");
+    String email = "test01@email.com";
+    String password = "test1234!";
+    SignupRequestDto requestDto;
+    if (!user1.isPresent()) {
+      requestDto = SignupRequestDto.builder()
+          .email(email).password(password).build();
+      SignUp(requestDto);
+    }
+  }
+  @Test
+  @Order(1)
+  @DisplayName("가게 생성")
+  void createStoreTest() throws IOException {
+    //given
+    String storeTitle1 = "TEST가게1";
+    String homePageLink1 = "가게 홈페이지 주소 1";
+    String category1 = "한식";
+    String address1 = "테스트1 가게 주소";
+    String roadAddress1 = "가게 도로명 주소 1";
+    String latitude1 = "가게 x좌표 1";
+    String longitude1 = "가게 y좌표 1";
+    //when
+    AdminStoreRequestDto requestDto1 = AdminStoreRequestDto.builder()
+        .title(storeTitle1)
+        .homePageLink(homePageLink1)
+        .category(category1)
+        .address(address1)
+        .roadAddress(roadAddress1)
+        .latitude(latitude1)
+        .longitude(longitude1)
+        .build();
+    //then
+    User user = userRepository.findByEmail("test01@email.com").orElse(null);
+    assertNotNull(user);
+    AdminStoreResponseDto responseDto1 = storeService.createStore(requestDto1, user);
+    assertNotNull(responseDto1);
+    assertNotNull(responseDto1.getId());  // 가게 생성 후 ID 값이 있는지 확인
+    assertEquals(storeTitle1, responseDto1.getTitle());
+    assertEquals(homePageLink1, responseDto1.getHomePageLink());
+    assertEquals(category1, responseDto1.getCategory());
+    assertEquals(address1, responseDto1.getAddress());
+    assertEquals(roadAddress1, responseDto1.getRoadAddress());
+    assertEquals(latitude1, responseDto1.getLatitude());
+    assertEquals(longitude1, responseDto1.getLongitude());
+  }
+
+  @Test
+  @Order(2)
+  @DisplayName("가게 수정하기")
+  void updateStoreTest() {
+    // Given
+    AdminStoreRequestDto requestDto = AdminStoreRequestDto.builder()
+        .title("Old Title")
+        .homePageLink("Old Link")
+        .category("Old Category")
+        .address("Old Address")
+        .roadAddress("Old Road Address")
+        .latitude("Old Latitude")
+        .longitude("Old Longitude")
+        .build();
+    User user = userRepository.findByEmail("test01@email.com").orElse(null);
+    assertNotNull(user);
+    AdminStoreResponseDto createdStore = storeService.createStore(requestDto, user);
+    Long storeId = createdStore.getId();
+
+    // When
+    AdminStoreRequestDto updateRequestDto = AdminStoreRequestDto.builder()
+        .title("Updated Title")
+        .homePageLink("Updated Link")
+        .category("Updated Category")
+        .address("Updated Address")
+        .roadAddress("Updated Road Address")
+        .latitude("Updated Latitude")
+        .longitude("Updated Longitude")
+        .build();
+    AdminStoreResponseDto updateStore = storeService.updateStore(storeId, updateRequestDto, user);
+
+    // Then
+    assertEquals(storeId, updateStore.getId());
+    assertEquals(updateRequestDto.getTitle(), updateStore.getTitle());
+    assertEquals(updateRequestDto.getHomePageLink(), updateStore.getHomePageLink());
+    assertEquals(updateRequestDto.getCategory(), updateStore.getCategory());
+    assertEquals(updateRequestDto.getAddress(), updateStore.getAddress());
+    assertEquals(updateRequestDto.getRoadAddress(), updateStore.getRoadAddress());
+    assertEquals(updateRequestDto.getLatitude(), updateStore.getLatitude());
+    assertEquals(updateRequestDto.getLongitude(), updateStore.getLongitude());
+
+  }
+
+  @Test
+  @Order(3)
+  @DisplayName("가게 아이디로 조회하기")
+  void getStoreByIdTest() {
+    // Given
+    AdminStoreRequestDto requestDto = AdminStoreRequestDto.builder()
+        .title("Test Store")
+        .homePageLink("Test Link")
+        .category("Test Category")
+        .address("Test Address")
+        .roadAddress("Test Road Address")
+        .latitude("Test Latitude")
+        .longitude("Test Longitude")
+        .build();
+    User user = userRepository.findByEmail("test01@email.com").orElse(null);
+    assertNotNull(user);
+    AdminStoreResponseDto createdStore = storeService.createStore(requestDto, user);
+    Long storeId = createdStore.getId();
+
+    // When
+    AdminStoreViewResponseDto storedStore = storeService.getStoreById(storeId, user);
+
+    // Then
+    assertEquals(storeId, storedStore.getId());
+    assertEquals("Test Store", storedStore.getTitle());
+    assertEquals("Test Link", storedStore.getHomePageLink());
+    assertEquals("Test Category", storedStore.getCategory());
+    assertEquals("Test Address", storedStore.getAddress());
+    assertEquals("Test Road Address", storedStore.getRoadAddress());
+
+  }
+
+  @Test
+  @Order(4)
+  @DisplayName("가게 삭제하기")
+  void deleteStoreTest() {
+    // Given
+    AdminStoreRequestDto requestDto = AdminStoreRequestDto.builder()
+        .title("Store to Delete")
+        .homePageLink("Delete Link")
+        .category("Delete Category")
+        .address("Delete Address")
+        .roadAddress("Delete Road Address")
+        .latitude("Delete Latitude")
+        .longitude("Delete Longitude")
+        .build();
+    User user = userRepository.findByEmail("test01@email.com").orElse(null);
+    assertNotNull(user);
+    AdminStoreResponseDto createdStore = storeService.createStore(requestDto, user);
+    Long storeId = createdStore.getId();
+
+    // When
+    storeService.deleteStore(storeId, user);
+
+    // Then
+    assertThrows(CustomException.class, () -> storeService.getStoreById(storeId, user));
+  }
+  @DisplayName("회원가입")
+  void SignUp(SignupRequestDto signupRequestDto) {
+    userService.signup(signupRequestDto);
+  }
+}

--- a/src/test/java/com/ocho/what2do/store/service/StoreServiceImplTest.java
+++ b/src/test/java/com/ocho/what2do/store/service/StoreServiceImplTest.java
@@ -1,28 +1,11 @@
 package com.ocho.what2do.store.service;
 
-import com.ocho.what2do.common.exception.CustomException;
-import com.ocho.what2do.store.dto.StoreRequestDto;
-import com.ocho.what2do.store.dto.StoreResponseDto;
-import com.ocho.what2do.store.dto.StoreViewResponseDto;
-import com.ocho.what2do.store.repository.StoreRepository;
-import com.ocho.what2do.user.dto.SignupRequestDto;
-import com.ocho.what2do.user.entity.User;
-import com.ocho.what2do.user.repository.UserRepository;
-import com.ocho.what2do.user.service.UserServiceImpl;
-import org.junit.jupiter.api.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-
-import java.io.IOException;
-import java.util.Optional;
-
-import static org.junit.Assert.*;
-
-@SpringBootTest
+// api 사용으로 인해 테스트 케이스 관리자 클래스에서 실행
+/*@SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)*/
 class StoreServiceImplTest {
-    @Autowired
+    /*@Autowired
     private UserServiceImpl userService;
     @Autowired
     private StoreServiceImpl storeService;
@@ -182,5 +165,5 @@ class StoreServiceImplTest {
     @DisplayName("회원가입")
     void SignUp(SignupRequestDto signupRequestDto) {
         userService.signup(signupRequestDto);
-    }
+    }*/
 }


### PR DESCRIPTION
## 관련 Issue

#33 

## 변경 사항

- api 를 활용함에 따라 기존 가게 등록, 수정 삭제는 관리자 페이지에서 가능 하도록 처리 
![admin가게등록테스트](https://github.com/ochoWhat2do/what2do/assets/42510512/2c544400-a61f-42d4-b35d-16774bf7c94e)

- 사용자 정지 : 특정한 이메일의 사용자를 로그인 못하게 처리 
![admin_사용자정지](https://github.com/ochoWhat2do/what2do/assets/42510512/9a1b0b48-f70c-4e1f-b515-8a800423f858)

![admin_사용자정지_예외처리](https://github.com/ochoWhat2do/what2do/assets/42510512/15455939-a24f-4a48-b1b1-6eda9c743017)

- 사용자 권한 변경 
![테스트2](https://github.com/ochoWhat2do/what2do/assets/42510512/3ac9dc59-899c-488f-bb8d-b2df946cf059)


## Todo List

추후 필요시 관리자 기능 추가할 것 

## Check List

<!-- 기능 구현을 다 했다면? --> 

- [x] 포스트맨으로 체크해 보았나요?

## 트러블 슈팅

- 정지 되었다면, 오류를 어떻게 처리할것인가? 
로그인 성공시 정지 여부에따라 exception 발생 시킴
