### PR TITLE
[update] 다음 API 개선

### DIFF
--- a/src/main/java/com/ocho/what2do/common/daum/controller/DaumApiController.java
+++ b/src/main/java/com/ocho/what2do/common/daum/controller/DaumApiController.java
@@ -1,7 +1,7 @@
 package com.ocho.what2do.common.daum.controller;
 
 import com.ocho.what2do.common.daum.service.DaumApiServiceImpl;
-import com.ocho.what2do.store.dto.StoreResponseDto;
+import com.ocho.what2do.store.dto.StoreListResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -9,8 +9,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,8 +20,8 @@ public class DaumApiController {
 
     @Operation(summary = "카카오 API 를 이용한 실시간 검색", description = "query(검색어)와, page(페이징, 최대 3)을 통해 실시간으로 데이터를 조회하고 DB에 저장하여 값을 리스트의 형태로 반환합니다.")
     @GetMapping("/search")
-    public List<StoreResponseDto> searchItems(@RequestParam String query,
-                                              @RequestParam String page) {
+    public StoreListResponseDto searchItems(@RequestParam String query,
+                                            @RequestParam String page) {
         return daumApiServiceImpl.searchItems(query, page);
     }
 }

--- a/src/main/java/com/ocho/what2do/common/daum/repository/ApiStoreRepository.java
+++ b/src/main/java/com/ocho/what2do/common/daum/repository/ApiStoreRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -17,4 +18,6 @@ public interface ApiStoreRepository extends JpaRepository<ApiStore, Long> {
     Page<ApiStore> findByCategoryContains(String category, Pageable pageable);
 
     Page<ApiStore> findAll(Pageable pageable);
+
+    List<ApiStore> findAllByCategoryContains(String category);
 }

--- a/src/main/java/com/ocho/what2do/common/daum/service/DaumApiService.java
+++ b/src/main/java/com/ocho/what2do/common/daum/service/DaumApiService.java
@@ -1,8 +1,6 @@
 package com.ocho.what2do.common.daum.service;
 
-import com.ocho.what2do.store.dto.StoreResponseDto;
-
-import java.util.List;
+import com.ocho.what2do.store.dto.StoreListResponseDto;
 
 public interface DaumApiService {
 
@@ -12,12 +10,12 @@ public interface DaumApiService {
      * @param page  조회할 페이지
      * @return 키워드로 조회된 목록
      */
-    List<StoreResponseDto> searchItems(String query, String page);
+    StoreListResponseDto searchItems(String query, String page);
 
     /**
      * JSON 처리를 도와주는 라이브러리를 추가하여 받아온 JSON 형태의 String 을 처리
      * @param responseEntity DAUM 검색 API 로 받아온 JSON 형태의 값을 String 으로 받아옴 (중첩 JSON)
      * @return 받아온 값을 Dto 로 변환하여 List 로 반환
      */
-    List<StoreResponseDto> fromJSONtoItems(String responseEntity);
+    StoreListResponseDto fromJSONtoItems(String responseEntity);
 }

--- a/src/main/java/com/ocho/what2do/common/message/CustomErrorCode.java
+++ b/src/main/java/com/ocho/what2do/common/message/CustomErrorCode.java
@@ -30,6 +30,7 @@ public enum CustomErrorCode {
   NOT_ADMIN_AUTH(HttpStatus.BAD_REQUEST.value(),"관리자 권한이 없습니다."),
   HAVE_NOT_USER_ROLE(HttpStatus.BAD_REQUEST.value(),"유효한 사용자 권한이 아닙니다."),
   LOGIN_USER_ACCOUNT_LOCKED(HttpStatus.BAD_REQUEST.value(),"계정이 정지되었습니다. 관리자에게 문의하세요."),
+  NOT_FOUND_PAGE(HttpStatus.BAD_REQUEST.value(), "존재하지 않는 페이지 입니다."),
   ;
 
   private final int errorCode;

--- a/src/main/java/com/ocho/what2do/store/dto/StoreCategoryListResponseDto.java
+++ b/src/main/java/com/ocho/what2do/store/dto/StoreCategoryListResponseDto.java
@@ -6,9 +6,13 @@ import java.util.List;
 
 @Getter
 public class StoreCategoryListResponseDto {
+    private Integer totalCnt;       // 검색 시 api 내의 모든 결과 값 갯수
+    private Boolean pageEnd;        // 마지막 페이지인지 아닌지 확인 (true : 마지막 페이지)
     private final List<StoreResponseDto> storeCategoryList;
 
-    public StoreCategoryListResponseDto(List<StoreResponseDto> storeCategoryList) {
+    public StoreCategoryListResponseDto(Integer totalCnt, Boolean pageEnd, List<StoreResponseDto> storeCategoryList) {
+        this.totalCnt = totalCnt;
+        this.pageEnd = pageEnd;
         this.storeCategoryList = storeCategoryList;
     }
 }

--- a/src/main/java/com/ocho/what2do/store/dto/StoreListResponseDto.java
+++ b/src/main/java/com/ocho/what2do/store/dto/StoreListResponseDto.java
@@ -1,14 +1,32 @@
 package com.ocho.what2do.store.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class StoreListResponseDto {
-    private List<StoreResponseDto> storesList;
+    private Integer totalCnt;   // 검색 시 api 내의 모든 결과 값 갯수
+    private Integer pageCnt;    // 모든 결과 값 중 볼 수 있는 자료 수 (최대 45) -> 필요한 부분인지 고민 할 필요 있어보임
+    private Boolean pageEnd;    // 마지막 페이지인지 아닌지 확인 (true : 마지막 페이지)
+    private String region;      // query(검색어)에서 지역 정보를 제외한 키워드
+    private String keyWord;     // query(검색어)에서 현재 검색에 사용된 지역 정보
+    private List<StoreResponseDto> storeList;   // 검색 가게 리스트
 
-    public StoreListResponseDto(List<StoreResponseDto> storeList) {
-        this.storesList = storeList;
+    public StoreListResponseDto(Integer totalCnt, Integer pageCnt, Boolean pageEnd, String keyWord, String region, List<StoreResponseDto> storeList) {
+        this.totalCnt = totalCnt;
+        this.pageCnt = pageCnt;
+        this.pageEnd = pageEnd;
+        this.keyWord = keyWord;
+        this.region = region;
+        this.storeList = storeList;
+    }
+
+    public StoreListResponseDto(Integer totalCnt, Boolean pageEnd, List<StoreResponseDto> storeList) {
+        this.totalCnt = totalCnt;
+        this.pageEnd = pageEnd;
+        this.storeList = storeList;
     }
 }


### PR DESCRIPTION
## 관련 Issue

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. -->

#47 

## 변경 사항

<!-- 이 Pull Request에서 어떤 점이 변경되었는지 간단하게 설명해주세요.
화면을 첨부한 설명이 필요한 경우 스크린샷을 첨부해 주세요 -->

1. 실시간 검색 조회
    - totalCnt 로 검색 시 조회되는 모든 값의 갯수를 확인할 수 있음
    - 하지만 api 의 한계로 조회할 수 있는 값은 45개로 제한되어 있음
![image](https://github.com/ochoWhat2do/what2do/assets/133615790/aca8cdda-5b5b-4e1a-b8ee-98c90beef1e8)

    - 현재는 한 페이지에 15건을 조회하도록 되어있어 3페이지가 마지막 페이지이므로 pageEnd 값이 true 로 반환됨
![image](https://github.com/ochoWhat2do/what2do/assets/133615790/a04df104-6b4c-4aa9-b301-f12a5ee128d0)

    - pageEnd 가 true 인 페이지 이후의 값을 입력 시 에러를 반환하도록 설정
![image](https://github.com/ochoWhat2do/what2do/assets/133615790/29c340e9-c154-4252-ae28-f05f23a69793)

2. 다음 API 의 Fallback

    - 실시간 조회 값들을 DB 에 저장하고, 저장값들을 토대로 다음 API 가 정상작동 하지 않았을 때의 차선책으로 전체 조회를 구현, DB 에 저장된 모든 값들의 갯수를 totalCnt 로 반환하고, pageEnd 도 마찬가지로 true 이후의 값은 에러를 반환하도록 설정
![image](https://github.com/ochoWhat2do/what2do/assets/133615790/4ba6ae1d-b7c9-4a28-8af3-2924ab604b73)

3. 카테고리 조회

    - DB 에 저장된 값들을 가지고 카테고리를 조회할 수 있도록 구현
    - 마찬가지로 totalCnt 로 카테고리 값이 포함된 모든 개수를 반환
    - pageEnd 기능도 동일
![image](https://github.com/ochoWhat2do/what2do/assets/133615790/d7ce5d18-3607-4ec7-bb42-67b63264ca42)

## Todo List

<!-- 이번 Pull Request 작업에서 아직 처리하지 못한 작업이나  
    추후에 해결해야 될 문제들을 기입해 주세요 -->  

1. 검색어인 "문래동 맛집" 에서 검색에 쓰인 keyWord 값과 region 값을 가져올 수 있는 것으로 보아 추후 해시태그 기능을 추가 할 시 도움이 될 것으로 보임 -> query 에 형식을 고정 시켜주면 좋을 것으로 보임

## Check List

<!-- 기능 구현을 다 했다면? --> 

- [x] 포스트맨으로 체크해 보았나요?


<!-- 있었던 오류나 발생했던 예외에 대해서 기록해 보세요. 정확한 설명을 위해 캡처화면을 활용해도 무방합니다. -->  


<!-- 오류 발생 케이스 --> 


<!-- 해결방안 --> 
