### PR TITLE
[fix] 리뷰조회, 좋아요 기능 수정

### DIFF
--- a/src/main/java/com/ocho/what2do/review/dto/ReviewLikeResponseDto.java
+++ b/src/main/java/com/ocho/what2do/review/dto/ReviewLikeResponseDto.java
@@ -18,7 +18,7 @@ public class ReviewLikeResponseDto {
         this.email = reviewLike.getUser().getEmail();
         this.nickname = reviewLike.getUser().getNickname();
         this.title = reviewLike.getReview().getTitle();
-
+        this.liked = reviewLike.getReview().getLikes().stream().filter(v -> v.getUser().equals(reviewLike.getUser())).toList().size() > 0;
     }
 
 }

--- a/src/main/java/com/ocho/what2do/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/ocho/what2do/review/dto/ReviewResponseDto.java
@@ -2,6 +2,9 @@ package com.ocho.what2do.review.dto;
 
 import com.ocho.what2do.common.file.S3FileDto;
 import com.ocho.what2do.review.entity.Review;
+import com.ocho.what2do.review.entity.ReviewLike;
+import com.ocho.what2do.user.entity.User;
+import java.util.Optional;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -20,6 +23,8 @@ public class ReviewResponseDto {
     private List<S3FileDto> attachment;
     private Long orderNo;
     private int rate;
+    private boolean liked;
+    private String createEmail;
 
     public ReviewResponseDto(Review review) {
         this.id = review.getId();
@@ -31,6 +36,26 @@ public class ReviewResponseDto {
         this.attachment = review.getAttachment();
         this.orderNo = review.getOrderNo();
         this.rate = review.getRate();
+        this.createEmail = review.getUser().getEmail();
+    }
+
+    public ReviewResponseDto(Review review, User loginUser) {
+        this.id = review.getId();
+        this.title = review.getTitle();
+        this.content = review.getContent();
+        this.createdAt = review.getCreatedAt();
+        this.modifiedAt = review.getModifiedAt();
+        this.likeCount = review.getLikes().size();
+        this.attachment = review.getAttachment();
+        this.orderNo = review.getOrderNo();
+        this.rate = review.getRate();
+        this.createEmail = review.getUser().getEmail();
+        Optional<ReviewLike> userLike = review.getLikes().stream().filter(v -> v.getUser().getId().equals(loginUser.getId())).findFirst();
+        if (userLike.isPresent()) {
+            this.liked = true;
+        } else {
+            this.liked = false;
+        }
     }
 
 }

--- a/src/main/java/com/ocho/what2do/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/ocho/what2do/review/service/ReviewServiceImpl.java
@@ -153,7 +153,7 @@ public class ReviewServiceImpl implements ReviewService {
     public ReviewResponseDto getReview(Long reviewId, User user) {
         Review review = findReview(reviewId);
 
-        return new ReviewResponseDto(review);
+        return new ReviewResponseDto(review, user);
     }
 
     @Override

--- a/src/main/java/com/ocho/what2do/user/entity/User.java
+++ b/src/main/java/com/ocho/what2do/user/entity/User.java
@@ -1,6 +1,8 @@
 package com.ocho.what2do.user.entity;
 
 
+import com.ocho.what2do.comment.entity.CommentLike;
+import com.ocho.what2do.review.entity.ReviewLike;
 import com.ocho.what2do.storefavorite.entity.StoreFavorite;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
@@ -37,6 +39,12 @@ public class User {
     @Column
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<StoreFavorite> storeFavorites = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<ReviewLike> reviewLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<CommentLike> commentLikes = new ArrayList<>();
 
     private String nickname;
 


### PR DESCRIPTION
## 관련 Issue

#53

## 변경 사항

![230905좋아요기능추가](https://github.com/ochoWhat2do/what2do/assets/42510512/bbebabab-e2a1-4737-91b2-7a4e3914624d)

- 리뷰 조회 시, 리뷰 작성한 사람의 이메일정보도 조회할 수 있도록 처리
-  리뷰상세정보 조회 시, 본인이 좋아요를 했는지 안했는지 체크하는 boolean 정보를 얻을 수 있도록 처리 


## Todo List

추후 개선사항 발생시 작업 예정

## Check List

<!-- 기능 구현을 다 했다면? --> 

- [x] 포스트맨으로 체크해 보았나요?


## 트러블 슈팅

<!-- 오류 발생 케이스 --> 



![230905_좋아요_에러](https://github.com/ochoWhat2do/what2do/assets/42510512/4e74ba00-179a-46db-8347-8f1ffd511623)


본인이 좋아요를 누른 사용자인지 확인하는 로직을 짰는데, 

해당 로직은 항상 true 로 밖에 나올 수 없었다. 

로그인한 사용자가 이미 좋아요를 눌렀는지 확인하려면 소스코드를 수정해야 했다. 

<!-- 해결방안 --> 


![230905_좋아요_에러해결](https://github.com/ochoWhat2do/what2do/assets/42510512/07339474-f3a0-4ad4-97be-ac53a3b94f1a)


생성자 선언 시, 로그인한 사용자 정보를 매개변수로 받도록 처리 