### PR TITLE
[feature]  https 적용과정에서 cors 예외처리

### DIFF
--- a/src/main/java/com/ocho/what2do/common/config/CorsConfig.java
+++ b/src/main/java/com/ocho/what2do/common/config/CorsConfig.java
@@ -21,6 +21,10 @@ public class CorsConfig {
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setExposedHeaders(List.of("*"));
+        config.setAllowedOrigins(List.of("https://www.what2do.co.kr"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("*"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);


### PR DESCRIPTION
## 관련 Issue

#75 

* 이슈 번호를 기재해주세요 (기입 예:#3)

## 변경 사항

aws에서 https 도메인적용 

## Todo List

도메인변경으로 인한 예외처리 발생시 처리

## Check List


- [x] 포스트맨으로 체크해 보았나요?

## 트러블 슈팅
cors exception 
![httpscors](https://github.com/ochoWhat2do/what2do/assets/42510512/c5968882-e26f-434f-9ab9-9678c1acf385)

https 도메인을프론트에 적용함으로써, 프론트에서 보낸요청에 cors 정책에 따라 막히게 되었다. 

따라서, spring security에서 cors 관련 문제를 처리해주어야한다. 

문제 원인 사진 

