### PR TITLE
[feature] 리뷰많은 목록 조회 페이징처리

### DIFF
--- a/src/main/java/com/ocho/what2do/store/dto/StoreResponseDto.java
+++ b/src/main/java/com/ocho/what2do/store/dto/StoreResponseDto.java
@@ -25,6 +25,8 @@ public class StoreResponseDto {
     private int viewCount;
     private  boolean favoriteYn;
 
+    private Long reviewCount; // reviewCount 필드 추가
+
     public StoreResponseDto(JSONObject itemJson) {
         this.storeKey = itemJson.getString("id");
         this.title = itemJson.getString("place_name");
@@ -59,6 +61,20 @@ public class StoreResponseDto {
         this.latitude = store.getLatitude();
         this.longitude = store.getLongitude();
         this.viewCount = store.getViewCount();
+    }
+
+    public StoreResponseDto(Store store, Long reviewCount) {
+        this.id = store.getId();
+        this.storeKey = store.getStoreKey();
+        this.title = store.getTitle();
+        this.homePageLink = store.getHomePageLink();
+        this.category = store.getCategory();
+        this.address = store.getAddress();
+        this.roadAddress = store.getRoadAddress();
+        this.latitude = store.getLatitude();
+        this.longitude = store.getLongitude();
+        this.viewCount = store.getViewCount();
+        this.reviewCount = reviewCount;
     }
 
     public StoreResponseDto(Store store, User loginUser) {

--- a/src/main/java/com/ocho/what2do/store/entity/StoreCountEntity.java
+++ b/src/main/java/com/ocho/what2do/store/entity/StoreCountEntity.java
@@ -1,0 +1,18 @@
+package com.ocho.what2do.store.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+// 조회용도로만사용하는 엔티티(리뷰 수 별 가게 리스트 조회)
+@Getter
+@Builder
+public class StoreCountEntity {
+  Long storeId;
+  Long reviewCount;
+
+  public StoreCountEntity(Long storeId, Long reviewCount) {
+    this.storeId = storeId;
+    this.reviewCount = reviewCount;
+  }
+
+}

--- a/src/main/java/com/ocho/what2do/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/ocho/what2do/store/repository/StoreRepositoryImpl.java
@@ -1,9 +1,21 @@
 package com.ocho.what2do.store.repository;
 
+import com.ocho.what2do.common.daum.entity.ApiStore;
 import com.ocho.what2do.store.dto.StoreResponseDto;
+import com.ocho.what2do.store.entity.StoreCountEntity;
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -19,51 +31,69 @@ import static com.ocho.what2do.store.entity.QStore.store;
 @Repository
 public class StoreRepositoryImpl implements CustomStoreRepository {
 
-    private final JPAQueryFactory queryFactory;
+  private final JPAQueryFactory queryFactory;
 
-    @Override
-    public List<StoreResponseDto> findStoresListReview(Pageable pageable) {
-        var query = queryFactory.select(store)
-                .from(apiStore)
-                .join(store).on(apiStore.storeKey.eq(store.storeKey))
-                .join(store.reviews, review)
-                .where(
-                        review.id.isNotNull()
-                )
-                //.limit(pageable.getPageSize())
-                .orderBy(store.reviews.size().desc());
-//.offset(pageable.getOffset())
-        var lists = query.fetch();
+  @Override
+  public List<StoreResponseDto> findStoresListReview(Pageable pageable) {
 
-        List<StoreResponseDto> responseList = lists.stream().map(
-                StoreResponseDto::new
-        ).toList();
+    var subQuery = queryFactory
+        .select(review.store.id.as("storeId"), review.count().as("reviewCount"))
+        .from(review)
+        .groupBy(review.store.id);
 
-        return responseList;
-    }
+    // 리뷰 개수가 있음
+    List<StoreCountEntity> storeContList = subQuery.stream().map(v ->
+        new StoreCountEntity(v.get(0, Long.class), v.get(1, Long.class))
+    ).toList();
 
-    /**
-     * OrderSpecifier 를 쿼리로 반환하여 정렬조건을 맞춰준다. 리스트 정렬
-     *
-     * @param page
-     * @return
-     */
-    private OrderSpecifier<?> storeSort(Pageable page) {
-        //서비스에서 보내준 Pageable 객체에 정렬조건 null 값 체크
-        if (!page.getSort().isEmpty()) {
-            //정렬값이 들어 있으면 for 사용하여 값을 가져온다
-            for (Sort.Order order : page.getSort()) {
-                // 서비스에서 넣어준 DESC or ASC 를 가져온다.
-                Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
-                // 서비스에서 넣어준 정렬 조건을 스위치 케이스 문을 활용하여 셋팅하여 준다.
-                switch (order.getProperty()) {
-                    case "title":
-                        return new OrderSpecifier(direction, store.title);
-                    case "createdAt":
-                        return new OrderSpecifier(direction, store.createdAt);
-                }
-            }
+    List<Long> storeIdList = storeContList.stream()
+        .map(StoreCountEntity::getStoreId)
+        .collect(Collectors.toList());
+
+    // StoreCountEntity의 storeId와 reviewCount를 매핑하는 Map을 생성
+    Map<Long, Long> storeIdToReviewCountMap = storeContList.stream()
+        .collect(Collectors.toMap(StoreCountEntity::getStoreId, StoreCountEntity::getReviewCount));
+
+    var query = queryFactory.select(store)
+        .from(apiStore)
+        .join(store).on(apiStore.storeKey.eq(store.storeKey))
+        .where(
+            store.id.in(storeIdList)
+        );
+
+    var lists = query.fetch();
+
+    List<StoreResponseDto> responseList = lists.stream()
+        .map(store -> new StoreResponseDto(store, storeIdToReviewCountMap.get(store.getId())))
+        .sorted(Comparator.comparingLong(StoreResponseDto::getReviewCount).reversed())
+        .limit(pageable.getPageSize()) // 프론트에서 받아온 페이지당 개수만큼만 보여준다
+        .collect(Collectors.toList());
+
+    return responseList;
+  }
+
+  /**
+   * OrderSpecifier 를 쿼리로 반환하여 정렬조건을 맞춰준다. 리스트 정렬
+   *
+   * @param page
+   * @return
+   */
+  private OrderSpecifier<?> storeSort(Pageable page) {
+    //서비스에서 보내준 Pageable 객체에 정렬조건 null 값 체크
+    if (!page.getSort().isEmpty()) {
+      //정렬값이 들어 있으면 for 사용하여 값을 가져온다
+      for (Sort.Order order : page.getSort()) {
+        // 서비스에서 넣어준 DESC or ASC 를 가져온다.
+        Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
+        // 서비스에서 넣어준 정렬 조건을 스위치 케이스 문을 활용하여 셋팅하여 준다.
+        switch (order.getProperty()) {
+          case "title":
+            return new OrderSpecifier(direction, store.title);
+          case "createdAt":
+            return new OrderSpecifier(direction, store.createdAt);
         }
-        return null;
+      }
     }
+    return null;
+  }
 }


### PR DESCRIPTION
## 관련 Issue

<!-- 해당 Pull Request와 관련된 Issue를 적습니다. -->

* 이슈 번호를 기재해주세요 (기입 예:#3)

## 변경 사항

![image](https://github.com/ochoWhat2do/what2do/assets/42510512/d2fd8c86-f264-429a-88c6-680de45a7726)

현재 페이징 기능이 querydsl 을 활용하여 적용되지 않아 
쿼리결과를 collection 객체로 변환 후 좋아요가 많은 순으로 정렬하고 
page 당 표시하는 게시물 숫자 만큼 화면에 가게정보를 표시하도록 처리 


![image](https://github.com/ochoWhat2do/what2do/assets/42510512/e1e01069-e9ea-4c23-81e5-17688e8eb7de)
페이징이 되지않아 리뷰가있는 게시물들이 많아 스크롤이 길어지기때문에  
페이징 기능 적용하여 top 5건만 나오도록 처리 

## Todo List
리뷰가 있는 페이지도 페이지 이동기능 추가해보면 좋을 것 같다. 

## Check List

<!-- 기능 구현을 다 했다면? --> 

- [x] 포스트맨으로 체크해 보았나요?
- [ ] 테스트 코드를 작성하셨나요?

## 트러블 슈팅

<!-- 오류 발생 케이스 --> 
QueryDsl 에서 from 이나 조인조건에 서브쿼리를 사용할 수 없다는 것을 알게되었다. 

<!-- 해결방안 --> 

쿼리문을 한번더 실행하여 

 서브쿼리문과 주 쿼리문을 각각 콜렉션으로 변환후 collection 객체에서 정렬및 페이징 적용