### PR TITLE
[refactor] 페이징 처리 시 

### DIFF
--- a/src/main/java/com/ocho/what2do/common/ConstVal.java
+++ b/src/main/java/com/ocho/what2do/common/ConstVal.java
@@ -1,0 +1,7 @@
+package com.ocho.what2do.common;
+
+public class ConstVal {
+
+  // API 스토어 정보는 페이지당 15건씩 조회되기 때문에  프론트에서 페이지 당 게시글 건수를 주지않고 백엔드에서 15로 고정
+  public static final int API_STORE_PAGE_PER_COUNT = 15;
+}

--- a/src/main/java/com/ocho/what2do/store/dto/StoreCategoryListResponseDto.java
+++ b/src/main/java/com/ocho/what2do/store/dto/StoreCategoryListResponseDto.java
@@ -7,10 +7,12 @@ import java.util.List;
 @Getter
 public class StoreCategoryListResponseDto {
     private Integer totalCnt;       // 검색 시 api 내의 모든 결과 값 갯수
+    private Integer pageCnt;   // 페이지 개수
     private final List<StoreResponseDto> storeCategoryList;
 
-    public StoreCategoryListResponseDto(Integer totalCnt, List<StoreResponseDto> storeCategoryList) {
+    public StoreCategoryListResponseDto(Integer totalCnt, Integer pageCnt, List<StoreResponseDto> storeCategoryList) {
         this.totalCnt = totalCnt;
+        this.pageCnt = pageCnt;
         this.storeCategoryList = storeCategoryList;
     }
 }

--- a/src/main/java/com/ocho/what2do/store/dto/StoreListResponseDto.java
+++ b/src/main/java/com/ocho/what2do/store/dto/StoreListResponseDto.java
@@ -22,8 +22,9 @@ public class StoreListResponseDto {
         this.storeList = storeList;
     }
 
-    public StoreListResponseDto(Integer totalCnt, List<StoreResponseDto> storeList) {
+    public StoreListResponseDto(Integer totalCnt, Integer pageCnt, List<StoreResponseDto> storeList) {
         this.totalCnt = totalCnt;
+        this.pageCnt = pageCnt;
         this.storeList = storeList;
     }
 }

--- a/src/main/java/com/ocho/what2do/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/ocho/what2do/store/service/StoreServiceImpl.java
@@ -1,5 +1,6 @@
 package com.ocho.what2do.store.service;
 
+import com.ocho.what2do.common.ConstVal;
 import com.ocho.what2do.store.entity.ApiStore;
 import com.ocho.what2do.store.repository.ApiStoreRepository;
 import com.ocho.what2do.common.exception.CustomException;
@@ -31,7 +32,7 @@ public class StoreServiceImpl implements StoreService {
     private final StoreRepository storeRepository;
     private final ApiStoreRepository apiStoreRepository;
     private final StoreFavoriteRepository storeFavoriteRepository;
-    private final int pageSize = 1000;    // 한 페이지에 출력할 데이터 갯수(변경 가능)
+    private final int pageSize = ConstVal.API_STORE_PAGE_PER_COUNT;    // 한 페이지에 출력할 데이터 갯수(API 받아온 정보라면 고정)
 
     @Override
     @Transactional(readOnly = true)
@@ -39,12 +40,12 @@ public class StoreServiceImpl implements StoreService {
         PageRequest pageRequest = pageable(page);
         List<StoreResponseDto> storeList = apiStoreRepository.findAll(pageRequest).stream().map(StoreResponseDto::new).collect(Collectors.toList());
         Integer totalCnt = apiStoreRepository.findAll().size();
-
-        if (pageCnt(totalCnt) < page) {
+        Integer pageCnt = pageCnt(totalCnt);
+        if (pageCnt < page) {
             throw new CustomException(CustomErrorCode.DATA_NOT_FOUND);
         }
 
-        return new StoreListResponseDto(totalCnt, storeList);
+        return new StoreListResponseDto(totalCnt, pageCnt, storeList);
     }
 
     @Override
@@ -82,11 +83,11 @@ public class StoreServiceImpl implements StoreService {
         PageRequest pageRequest = pageable(page);
         List<StoreResponseDto> storeCategory = apiStoreRepository.findByCategoryContains(category, pageRequest).stream().map(StoreResponseDto::new).toList();
         Integer totalCnt = apiStoreRepository.findAllByCategoryContains(category).stream().toList().size();
-
-        if (pageCnt(totalCnt) < page || totalCnt == 0) {
+        Integer pageCnt = pageCnt(totalCnt);
+        if (pageCnt < page || totalCnt == 0) {
             throw new CustomException(CustomErrorCode.DATA_NOT_FOUND);
         }
-        return new StoreCategoryListResponseDto(totalCnt, storeCategory);
+        return new StoreCategoryListResponseDto(totalCnt, pageCnt, storeCategory);
     }
 
     @Override


### PR DESCRIPTION
ConstVal : 공통상수 사용

카카오에서 제공하는 1회조회 건수보다 적을때 페이지 수를 리턴하도록 처리

## 관련 Issue

#41



## 변경 사항
![조회수가적을때 페이지개수동적으로변하도록처리](https://github.com/ochoWhat2do/what2do/assets/42510512/989dcd67-7f7d-458a-a492-bcf43174792d)


## Todo List

페이징 처리 상세한 테스트 코드 작성해볼 것 

## Check List



- [x] 포스트맨으로 체크해 보았나요?

## 트러블 슈팅

카카오에서 1페이당 제공건수는 15 건이다 

그래서 공통 상수로 15를 지정하여 

api 호출 시 페이지수를 고정 처리