### PR TITLE
[feature] 스케쥴러 이미지 업로드 기능개발

### DIFF
--- a/src/main/java/com/ocho/what2do/common/sceduler/StoreImageScheduler.java
+++ b/src/main/java/com/ocho/what2do/common/sceduler/StoreImageScheduler.java
@@ -18,7 +18,7 @@ public class StoreImageScheduler {
 
   // @Scheduled(cron = "* */10 * * * *", zone = "Asia/Seoul") //10 분마다
   // 초, 분, 시, 일, 월, 주 순서
-  @Scheduled(cron = "0 42 14 * * *", zone = "Asia/Seoul") // 매일 새벽 1시
+  @Scheduled(cron = "0 0 6 * * *", zone = "Asia/Seoul") // 매일 새벽 6시
   public void yourScheduledMethod() {
     // 스케줄러가 실행될 로직
     log.info("가게 이미지 등록 스케줄러 실행");

--- a/src/main/java/com/ocho/what2do/store/entity/Store.java
+++ b/src/main/java/com/ocho/what2do/store/entity/Store.java
@@ -79,6 +79,11 @@ public class Store extends Timestamped {
         this.images = requestDto.getImages();
     }
 
+    // 이미지 업데이트
+    public void updateImages(List<S3FileDto> images) {
+        this.images = images;
+    }
+
     public void increaseViewCount() {
         this.viewCount++;
     }

--- a/src/main/java/com/ocho/what2do/store/repository/StoreRepositoryImpl.java
+++ b/src/main/java/com/ocho/what2do/store/repository/StoreRepositoryImpl.java
@@ -6,8 +6,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ocho.what2do.common.file.S3FileDto;
 import com.ocho.what2do.store.dto.StoreResponseDto;
 import com.ocho.what2do.store.entity.StoreCountEntity;
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import java.util.Comparator;
@@ -53,6 +55,7 @@ public class StoreRepositoryImpl implements CustomStoreRepository {
     Map<Long, Long> storeIdToReviewCountMap = storeContList.stream()
         .collect(Collectors.toMap(StoreCountEntity::getStoreId, StoreCountEntity::getReviewCount));
 
+    Expression<String> jsonImages = Expressions.stringTemplate("CAST({0} AS text)", apiStore.images).as("images");
     var query = queryFactory.select(
             store.id.as("is"),
             apiStore.storeKey.as("storeKey"),
@@ -64,7 +67,7 @@ public class StoreRepositoryImpl implements CustomStoreRepository {
             store.latitude.as("latitude"),
             store.longitude.as("longitude"),
             store.viewCount.as("viewCount"),
-            apiStore.images.as("images")
+            jsonImages // 타입을 명시
         )
         .from(apiStore)
         .join(store).on(apiStore.storeKey.eq(store.storeKey))

--- a/src/main/java/com/ocho/what2do/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/ocho/what2do/store/service/StoreServiceImpl.java
@@ -88,6 +88,12 @@ public class StoreServiceImpl implements StoreService {
     if (savedStore.isPresent()) {
       return new StoreResponseDto(savedStore.get(), user);
     } else {
+      // API 정보에 이미지가 있고  STORE 테이블에 이미지가 없을경우 업데이트
+      if (findStore.getImages() != null) {
+        if (store.getImages() == null) {
+          store.updateImages(findStore.getImages());
+        }
+      }
       return new StoreResponseDto(findStore);
     }
   }


### PR DESCRIPTION
## 관련 Issue

#97 



## 변경 사항
스케쥴러 이미지 업로드 기능개발(시간 아침 6시 고정)
리뷰가 많은 순서로 조회하는기능 오류 수정
상세 페이지 이동시 가게이미지 나오도록 수정


## Todo List

누락된 이미지에 대한 반영을 어떻게 할것인가? (관리자 수동등록도 방법)

## Check List

- [x] 포스트맨으로 체크해 보았나요?

## 트러블 슈팅

리뷰가 많은 가게 목록이 나오지 않는 현상 
db에서 가져오는 컬럼은 json 타입인데 

querydsl 을 써서 조회하여 사용할때는 string으로 사용하고 있었다. 

변환 과정에서 에러 발생 

<!-- 해결방안 --> 

![image](https://github.com/ochoWhat2do/what2do/assets/42510512/64dca5cd-dc53-47f7-ac7f-ab893720d2ea)

해당 json 컬럼값을 
string 으로 변환 후 사용하도록 처리 
