### PR TITLE
[feature] 관리자 가게 수정기능 추가

### DIFF
--- a/src/main/java/com/ocho/what2do/admin/controller/AdminStoreController.java
+++ b/src/main/java/com/ocho/what2do/admin/controller/AdminStoreController.java
@@ -1,6 +1,10 @@
 package com.ocho.what2do.admin.controller;
 
 
+import com.ocho.what2do.admin.dto.AdminApiStoreListResponseDto;
+import com.ocho.what2do.admin.dto.AdminApiStoreRequestDto;
+import com.ocho.what2do.admin.dto.AdminApiStoreResponseDto;
+import com.ocho.what2do.admin.dto.AdminApiStoreViewResponseDto;
 import com.ocho.what2do.admin.dto.AdminStoreListResponseDto;
 import com.ocho.what2do.admin.dto.AdminStoreRequestDto;
 import com.ocho.what2do.admin.dto.AdminStoreResponseDto;
@@ -31,22 +35,45 @@ public class AdminStoreController {
     return new ResponseEntity<>(storeService.createStore(requestDto, userDetails.getUser(),files), HttpStatus.OK);
   }
 
-  @Operation(summary = "관리자 가게 전체 조회", description = "가게를 조회합니다.")
-  @GetMapping("/stores") //가게 전체 조회
-  public ResponseEntity<AdminStoreListResponseDto> getStores() {
-    AdminStoreListResponseDto result = storeService.getStores();
+  @Operation(summary = "관리자 API 데이터 전체 조회", description = "가게를 조회합니다.")
+  @GetMapping("/stores")
+  public ResponseEntity<AdminApiStoreListResponseDto> getStores(
+      @RequestParam("keyword") String keyword,
+      @RequestParam("page") int page,
+      @RequestParam("size") int size,
+      @RequestParam("sortBy") String sortBy,
+      @RequestParam("isAsc") boolean isAsc
+  ) {
+    AdminApiStoreListResponseDto result = storeService.getStores(keyword, page, size, sortBy, isAsc);
 
     return ResponseEntity.ok().body(result);
   }
 
-  @Operation(summary = "관리자 가게 전체 조회", description = "가게를 조회합니다.")
-  @GetMapping("/stores/{storeId}") //가게 단건 조회
+  @Operation(summary = "관리자 가게 API STORE 조회", description = "API STORE KEY로 가게를 조회합니다.")
+  @GetMapping("/stores/{storeKey}")
+  public ResponseEntity<AdminApiStoreViewResponseDto> getApiStoreStoreKey(@PathVariable String storeKey, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+    return new ResponseEntity<>(storeService.getApiStoreByStoreKey(storeKey, userDetails.getUser()), HttpStatus.OK);
+  }
+
+  @Operation(summary = "관리자 가게 조회", description = "가게를 조회합니다.")
+  @GetMapping("/detail-stores/{storeId}")
   public ResponseEntity<AdminStoreViewResponseDto> getStoreById(@PathVariable Long storeId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
     return new ResponseEntity<>(storeService.getStoreById(storeId, userDetails.getUser()), HttpStatus.OK);
   }
 
+  @Operation(summary = "API 관리자 가게 수정", description = "가게를 수정합니다.")
+  @PutMapping("/stores/{storeKey}") //가게 수정
+  public ResponseEntity<AdminApiStoreResponseDto> updateApiStore(@AuthenticationPrincipal UserDetailsImpl userDetails
+      , @PathVariable String storeKey
+      , @RequestPart AdminApiStoreRequestDto requestDto
+      , @RequestPart(required = false) List<MultipartFile> files) {
+    AdminApiStoreResponseDto result;
+    result = storeService.updateApiStore(storeKey, requestDto, userDetails.getUser(), files);
+    return ResponseEntity.ok().body(result);
+  }
+
   @Operation(summary = "관리자 가게 수정", description = "가게를 수정합니다.")
-  @PutMapping("/stores/{storeId}") //가게 수정
+  @PutMapping("/detail-stores/{storeId}") //가게 수정
   public ResponseEntity<ApiResponseDto> updateStore(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long storeId, @RequestPart AdminStoreRequestDto requestDto,  @RequestPart(required = false) List<MultipartFile> files) {
     AdminStoreResponseDto result;
     result = storeService.updateStore(storeId, requestDto, userDetails.getUser(), files);

--- a/src/main/java/com/ocho/what2do/admin/dto/AdminApiStoreListResponseDto.java
+++ b/src/main/java/com/ocho/what2do/admin/dto/AdminApiStoreListResponseDto.java
@@ -1,0 +1,18 @@
+package com.ocho.what2do.admin.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class AdminApiStoreListResponseDto {
+  private Long totalCount;   // 총 리뷰 건수
+  private int pageCount;    // 페이지 개수
+
+  private List<AdminApiStoreResponseDto> storeList;
+
+  public AdminApiStoreListResponseDto(Long totalCount, int pageCount, List<AdminApiStoreResponseDto> storeList) {
+    this.totalCount = totalCount;
+    this.pageCount = pageCount;
+    this.storeList = storeList;
+  }
+}

--- a/src/main/java/com/ocho/what2do/admin/dto/AdminApiStoreRequestDto.java
+++ b/src/main/java/com/ocho/what2do/admin/dto/AdminApiStoreRequestDto.java
@@ -1,0 +1,17 @@
+package com.ocho.what2do.admin.dto;
+
+import com.ocho.what2do.common.file.S3FileDto;
+import java.util.List;
+import lombok.Builder;
+
+public class AdminApiStoreRequestDto {
+
+ private boolean locked;
+ private List<S3FileDto> images;
+
+  @Builder
+  public AdminApiStoreRequestDto(boolean locked, List<S3FileDto> images) {
+    this.locked = locked;
+    this.images = images;
+  }
+}

--- a/src/main/java/com/ocho/what2do/admin/dto/AdminApiStoreResponseDto.java
+++ b/src/main/java/com/ocho/what2do/admin/dto/AdminApiStoreResponseDto.java
@@ -1,0 +1,38 @@
+package com.ocho.what2do.admin.dto;
+
+import com.ocho.what2do.common.file.S3FileDto;
+import com.ocho.what2do.store.entity.ApiStore;
+import com.ocho.what2do.store.entity.Store;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminApiStoreResponseDto {
+  private Long id;
+  private String title;
+  private String homePageLink;
+  private String category;
+  private String address;
+  private String roadAddress;
+  private String latitude;
+  private String longitude;
+  private boolean isStoreFavorite = false;
+  private List<S3FileDto> images;
+  private String storeKey;
+
+  public AdminApiStoreResponseDto(ApiStore store) {
+    this.id = store.getId();
+    this.title = store.getTitle();
+    this.homePageLink = store.getHomePageLink();
+    this.category = store.getCategory();
+    this.address = store.getAddress();
+    this.roadAddress = store.getRoadAddress();
+    this.latitude = store.getLatitude();
+    this.longitude = store.getLongitude();
+    this.isStoreFavorite = false;
+    this.images = store.getImages();
+    this.storeKey = store.getStoreKey();
+  }
+}

--- a/src/main/java/com/ocho/what2do/admin/dto/AdminApiStoreViewResponseDto.java
+++ b/src/main/java/com/ocho/what2do/admin/dto/AdminApiStoreViewResponseDto.java
@@ -1,0 +1,31 @@
+package com.ocho.what2do.admin.dto;
+
+import com.ocho.what2do.common.file.S3FileDto;
+import com.ocho.what2do.store.entity.ApiStore;
+import com.ocho.what2do.store.entity.Store;
+import com.ocho.what2do.user.entity.User;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminApiStoreViewResponseDto {
+  private Long id;
+  private String title;
+  private String homePageLink;
+  private String category;
+  private String address;
+  private String roadAddress;
+  private List<S3FileDto> images;
+
+  public AdminApiStoreViewResponseDto(ApiStore store) {
+    this.id = store.getId();
+    this.title = store.getTitle();
+    this.homePageLink = store.getHomePageLink();
+    this.category = store.getCategory();
+    this.address = store.getAddress();
+    this.roadAddress = store.getRoadAddress();
+    this.images = store.getImages();
+  }
+}

--- a/src/main/java/com/ocho/what2do/admin/service/AdminStoreService.java
+++ b/src/main/java/com/ocho/what2do/admin/service/AdminStoreService.java
@@ -1,9 +1,14 @@
 package com.ocho.what2do.admin.service;
 
+import com.ocho.what2do.admin.dto.AdminApiStoreListResponseDto;
+import com.ocho.what2do.admin.dto.AdminApiStoreRequestDto;
+import com.ocho.what2do.admin.dto.AdminApiStoreResponseDto;
+import com.ocho.what2do.admin.dto.AdminApiStoreViewResponseDto;
 import com.ocho.what2do.admin.dto.AdminStoreListResponseDto;
 import com.ocho.what2do.admin.dto.AdminStoreRequestDto;
 import com.ocho.what2do.admin.dto.AdminStoreResponseDto;
 import com.ocho.what2do.admin.dto.AdminStoreViewResponseDto;
+import com.ocho.what2do.store.entity.ApiStore;
 import com.ocho.what2do.store.entity.Store;
 import com.ocho.what2do.user.entity.User;
 import org.springframework.web.multipart.MultipartFile;
@@ -26,7 +31,7 @@ public interface AdminStoreService {
    * 전체 가게 목록 조회
    * @return 전체 가게 목록
    */
-  AdminStoreListResponseDto getStores();
+  AdminApiStoreListResponseDto getStores(String keyword, int page, int size, String sortBy, boolean isAsc);
 
   /**
    * 가게 단건 조회
@@ -34,6 +39,24 @@ public interface AdminStoreService {
    * @return 조회된 가게 정보
    */
   AdminStoreViewResponseDto getStoreById(Long storeId, User user);
+
+  /**
+   * API 가게 단건 조회
+   * @param storeKey 조회할 가게 StoreKey
+   * @return 조회된 가게 정보
+   */
+  AdminApiStoreViewResponseDto getApiStoreByStoreKey(String storeKey, User user);
+
+  /**
+   * API 가게 업데이트
+   *
+   * @param storeKey    업데이트 할 가게
+   * @param requestDto 업데이트 할 가게 정보
+   * @param user       가게 업데이트 요청자
+   * @param files      업데이트할 가게 첨부 사진
+   * @return 업데이트된 가게 정보
+   */
+  AdminApiStoreResponseDto updateApiStore(String storeKey, AdminApiStoreRequestDto requestDto, User user, List<MultipartFile> files);
 
   /**
    * 가게 업데이트
@@ -54,10 +77,24 @@ public interface AdminStoreService {
   void deleteStore(Long storeId, User user);
 
   /**
+   * API 가게 Entity 단건 조회
+   * @param storeKey 조회할 가게 ID
+   * @return 가게 Entity
+   */
+  ApiStore findApiStore(String storeKey);
+
+  /**
    * 가게 Entity 단건 조회
    * @param storeId 조회할 가게 ID
    * @return 가게 Entity
    */
   Store findStore(Long storeId);
+
+  /**
+   * 사용자 찾기
+   * @param user 사용자 찾기
+   * @return 가게 Entity
+   */
+  User findUser(User user);
 
 }

--- a/src/main/java/com/ocho/what2do/store/repository/ApiStoreRepository.java
+++ b/src/main/java/com/ocho/what2do/store/repository/ApiStoreRepository.java
@@ -21,6 +21,8 @@ public interface ApiStoreRepository extends JpaRepository<ApiStore, Long> {
 
     Page<ApiStore> findAll(Pageable pageable);
 
+    Page<ApiStore> findAllByTitleLike(String title, Pageable pageable);
+
     List<ApiStore> findAllByCategoryContains(String category);
 
     Optional<ApiStore> findByStoreKey(String storeKey);

--- a/src/main/java/com/ocho/what2do/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/ocho/what2do/store/service/StoreServiceImpl.java
@@ -90,8 +90,9 @@ public class StoreServiceImpl implements StoreService {
     } else {
       // API 정보에 이미지가 있고  STORE 테이블에 이미지가 없을경우 업데이트
       if (findStore.getImages() != null) {
-        if (store.getImages() == null) {
-          store.updateImages(findStore.getImages());
+        Store savedStoreEntity = savedStore.get();
+        if (savedStoreEntity.getImages() == null) {
+          savedStoreEntity.updateImages(findStore.getImages());
         }
       }
       return new StoreResponseDto(findStore);

--- a/src/main/java/com/ocho/what2do/user/service/UserServiceImpl.java
+++ b/src/main/java/com/ocho/what2do/user/service/UserServiceImpl.java
@@ -78,7 +78,9 @@ public class UserServiceImpl implements UserService {
   @Override
   public void deleteUserInfo(WithdrawalRequestDto requestDto, User user) {
     User found = findUser(user.getId());
-    checkPassword(requestDto.getPassword(), found.getPassword());
+    if(user.getSocialType() == null) {
+      checkPassword(requestDto.getPassword(), found.getPassword());
+    }
     confirmUser(found, user);
 
     reviewRepository.deleteAllByUserId(user.getId());


### PR DESCRIPTION
## 관련 Issue

#111 



## 변경 사항

관리자 이미지 수정 기능 개선
회원 탈퇴시 소셜로그인을 했다면 비밀번호체크하지않도록 처리 
관리자 이미지 페이징 조회 기능 추가 


## Todo List

사용자관리페이지 개발

## Check List

- [x] 포스트맨으로 체크해 보았나요?

![0917_관리자조회화면개발](https://github.com/ochoWhat2do/what2do/assets/42510512/9d29d773-bc90-4d31-be38-44e75e6d49fe)
- 관리자의 가게조회화면

![0917_관리자수정화면개발](https://github.com/ochoWhat2do/what2do/assets/42510512/0dab922b-0f8d-4c59-92f2-04a584ed5bc4)
- 관리자의 이미지 수정



## 트러블 슈팅

api 정보를 실시간으로 조회하는 api_store 테이블과 store 테이블 둘다 이미지 수정이 필요하다. 

api_store 는 정보를 실시간 조회하는데 어떻게 실시간 조회 캐싱기능에 영향을 안미치고 
이미지 업로드 수정을 할지 고민하였다. 

<!-- 해결방안 --> 

조회나 수정 시, 캐싱이 되어있는 메소드는 호출하지 않는 방향으로 처리 

